### PR TITLE
Fix parse_ip_range to iterate IP addresses

### DIFF
--- a/rtsp_scan.py
+++ b/rtsp_scan.py
@@ -26,7 +26,15 @@ def parse_ip_range(ip_range):
         start_ip, end_ip = ip_range.split('-')
         start = ipaddress.IPv4Address(start_ip)
         end = ipaddress.IPv4Address(end_ip)
-        return [str(ip) for ip in ipaddress.summarize_address_range(start, end)]
+
+        if int(end) < int(start):
+            raise ValueError("End IP must be greater than or equal to start IP")
+
+        ip_list = []
+        for ip_int in range(int(start), int(end) + 1):
+            ip_list.append(str(ipaddress.IPv4Address(ip_int)))
+
+        return ip_list
     except Exception as e:
         print(f"Error parsing IP range: {e}")
         return []


### PR DESCRIPTION
## Summary
- update `parse_ip_range` to return each IP string using `ipaddress.IPv4Address`

## Testing
- `python -m py_compile rtsp_scan.py`
- `python - <<'PY'
import rtsp_scan
print(rtsp_scan.parse_ip_range('192.168.1.1-192.168.1.3'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6844955f1c108329820d9c7cd1cc55eb